### PR TITLE
README: fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See [License File](LICENSE).
 
 #### GHCUp
 
-`sudo apt-get install build-essential zlib1g-dev`
+`sudo apt-get install build-essential curl libffi-dev libffi8 libgmp-dev libgmp10 libncurses-dev libncurses5 libtinfo5`
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ ghcup set cabal 3.10.3.0
 #### For QT:
 
 ```bash
-sudo apt-get install qtdeclarative5-dev && \
-                     libqt5quick5 && \
-                     qttools5-dev-tools && \
-                     qtbase5-dev && \
+sudo apt-get install qtdeclarative5-dev \
+                     libqt5quick5 \
+                     qttools5-dev-tools \
+                     qtbase5-dev \
                      qt5-image-formats-plugins
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ ghcup set cabal 3.10.3.0
 ```bash
 sudo apt-get install qtdeclarative5-dev \
                      libqt5quick5 \
+                     qml-module-qtquick-controls \
+                     qml-module-qtquick-controls2 \
                      qttools5-dev-tools \
                      qtbase5-dev \
                      qt5-image-formats-plugins


### PR DESCRIPTION
The list of ghcup dependencies was not complete. I copied the full list from https://www.haskell.org/ghcup/install/#version-12

Qt installation command didn't work. I fixed it.