### PR TITLE
remove followRelay from Follow type

### DIFF
--- a/resources/qml/content/MainContent.ui.qml
+++ b/resources/qml/content/MainContent.ui.qml
@@ -26,7 +26,9 @@ Rectangle {
 
         onMessageSubmitted: function(text) {
             if (targetPost.postType == "repost") {
-                quoteRepost(targetPost.referencedEventId, text)
+                if (targetPost.referencedPosts.length > 0) {
+                    quoteRepost(targetPost.referencedPosts[0].id, text)
+                }
             } else {
                 quoteRepost(targetPost.id, text)
             }


### PR DESCRIPTION
The followRelay field in the Follow type has been removed as it's redundant with NIP-65 (RelayListMetadata). Instead of storing relay information with each follow, we now rely on RelayListMetadata events to discover which relays to use for each contact.

- Reduces complexity in follow list handling
- Removes duplicate relay information storage

event ID handling and post notifications

- Fix event ID serialization to avoid double quotes in QML
- Add missing notifications for post changes
- Store events locally before publishing
- Fix repost handling in MainContent.qml