### PR TITLE
changed NIP-01 to only allow a single filter per REQ

### DIFF
--- a/src/Futr.hs
+++ b/src/Futr.hs
@@ -47,8 +47,7 @@ import Nostr.Publisher
 import Nostr.RelayConnection (RelayConnection)
 import Nostr.RelayPool
 import Nostr.Subscription
-import Nostr.Types ( Event(..), EventId, Relay(..), RelayURI, Tag(..)
-                   , getUri, metadataFilter )
+import Nostr.Types (Event(..), EventId, Relay(..), RelayURI, Tag(..), getUri)
 import Nostr.Util
 import Presentation.KeyMgmtUI (KeyMgmtUI)
 import Presentation.RelayMgmtUI (RelayMgmtUI)
@@ -459,7 +458,7 @@ searchInRelays pubkey' _ = do
         let relayUri' = getUri relay
         when (Map.member relayUri' conns) $ do
           subId' <- newSubscriptionId
-          mq <- subscribe relayUri' subId' [metadataFilter [pubkey']]
+          mq <- subscribe relayUri' subId' $ metadataFilter [pubkey']
           case mq of
               Nothing -> return ()
               Just q -> void $ async $ do
@@ -467,7 +466,7 @@ searchInRelays pubkey' _ = do
                         e <- atomically $ readTQueue q
                         case e of
                           EventAppeared event' -> do
-                            updates <- handleEvent relayUri' subId' [metadataFilter [pubkey']] event'
+                            updates <- handleEvent relayUri' subId' (metadataFilter [pubkey']) event'
                             notify updates
                             loop
                           SubscriptionEose -> do

--- a/src/Nostr/Event.hs
+++ b/src/Nostr/Event.hs
@@ -16,7 +16,7 @@ import System.Random (randomRIO)
 
 import Nostr.Bech32 (eventToNevent)
 import Nostr.Keys
-import Nostr.Types
+import Nostr.Types hiding (filter)
 import Nostr.Encryption (decrypt, getConversationKey, encrypt)
 
 

--- a/src/Nostr/RelayConnection.hs
+++ b/src/Nostr/RelayConnection.hs
@@ -275,7 +275,7 @@ handleResponse relayURI' r = case r of
                             Just subDetails -> do
                                 let subscription = NT.Subscription
                                         { NT.subId = subId'
-                                        , NT.filters = subscriptionFilters subDetails
+                                        , NT.filter = subscriptionFilter subDetails
                                         }
                                 handleAuthRequired relayURI' (NT.Subscribe subscription)
                             Nothing -> logError $ "No subscription found for " <> T.pack (show subId')

--- a/src/Presentation/RelayMgmtUI.hs
+++ b/src/Presentation/RelayMgmtUI.hs
@@ -21,7 +21,7 @@ import QtQuick (QtQuickState(..), UIReferences(..))
 import Logging
 import Nostr.Keys (keyPairToPubKeyXO)
 import Nostr.RelayPool
-import Nostr.Types hiding (displayName, picture)
+import Nostr.Types hiding (displayName, filter, picture)
 import Nostr.Util
 import Types (AppState(..), ConnectionState(..), RelayData(..), RelayPoolState(..))
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -43,7 +43,7 @@ data RelayPoolState = RelayPoolState
 -- | Subscription details.
 data SubscriptionDetails = SubscriptionDetails
     { subscriptionId :: SubscriptionId
-    , subscriptionFilters :: [Filter]
+    , subscriptionFilter :: Filter
     , responseQueue :: TQueue SubscriptionEvent
     , eventsProcessed :: Int
     , newestCreatedAt :: Int


### PR DESCRIPTION
- use a single subscription filter
- Add event counting subscriptions for reactions, reposts and comments
- Implement helper functions for event counting
- Expose count properties in UI for post objects
- move all filters to nostr.subscription
- simplify filter implementations

implements https://github.com/nostr-protocol/nips/pull/1645