### PR TITLE
Fixes for Subscripton Handling and Caching

### DIFF
--- a/resources/qml/content/FollowList.ui.qml
+++ b/resources/qml/content/FollowList.ui.qml
@@ -40,7 +40,6 @@ Rectangle {
                     mode: AutoListModel.ByKey
                     equalityTest: function (oldItem, newItem) {
                         return oldItem.pubkey === newItem.pubkey
-                            && oldItem.relay === newItem.relay
                             && oldItem.petname === newItem.petname
                             && oldItem.displayName === newItem.displayName
                             && oldItem.name === newItem.name

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -25,6 +25,7 @@ import Store.Lmdb (LmdbState, initialLmdbState, runLmdbStore)
 import Types (AppState(..), RelayPool(..))
 import Types qualified as Types
 
+
 -- | Main function for the app.
 main :: IO ()
 main = do

--- a/src/Nostr/Event.hs
+++ b/src/Nostr/Event.hs
@@ -84,28 +84,28 @@ createComment originalEvent content' rootScope parentItem relayHint xo t =
         -- Root scope tags
         rootTags = case root of
           Left (ITag val _) -> 
-            [ ITag val relay
+            [ ITag val Nothing
             , KTag (pack $ show $ kind originalEvent)
             ]
           Right eid ->
-            [ ETag eid relay Nothing
+            [ ETag eid relay Nothing Nothing
             , KTag (pack $ show $ kind originalEvent)
             ]
           _ -> error "Invalid root scope tag"
 
         -- Parent tags (for replies)
         parentTags = case parent of
-          Just (ETag eid _ mpk) ->
-            [ ETag eid relay mpk
+          Just (ETag eid _ mpk _) ->
+            [ ETag eid relay mpk Nothing
             , KTag (pack $ show Comment)
             ]
           Just (ITag val _) ->
-            [ ITag val relay
+            [ ITag val Nothing
             , KTag (pack $ show $ kind originalEvent)
             ]
           Nothing -> case root of
             Left itag@(ITag _ _) -> [itag, KTag (pack $ show Comment)]
-            Right eid -> [ETag eid relay Nothing, KTag (pack $ show Comment)]
+            Right eid -> [ETag eid relay Nothing Nothing, KTag (pack $ show Comment)]
             _ -> []
           _ -> error "Invalid parent tag"
       in
@@ -119,7 +119,7 @@ createRepost event relayUrl xo t =
     { pubKey' = xo
     , createdAt' = t
     , kind' = Repost
-    , tags' = [ ETag (eventId event) (Just relayUrl) Nothing
+    , tags' = [ ETag (eventId event) (Just relayUrl) Nothing Nothing
               , PTag (pubKey event) Nothing Nothing
               ]
     , content' = decodeUtf8 $ toStrict $ encode event
@@ -146,7 +146,7 @@ createGenericRepost event relayUrl xo t =
     { pubKey' = xo
     , createdAt' = t
     , kind' = GenericRepost
-    , tags' = [ ETag (eventId event) (Just relayUrl) Nothing
+    , tags' = [ ETag (eventId event) (Just relayUrl) Nothing Nothing
               , PTag (pubKey event) Nothing Nothing
               , KTag (pack $ show $ kind event)
               ]
@@ -185,7 +185,7 @@ createReplyNote event note xo t =
     { pubKey' = xo
     , createdAt' = t
     , kind' = ShortTextNote
-    , tags' = [ETag (eventId event) Nothing (Just Reply)]
+    , tags' = [ETag (eventId event) Nothing (Just Reply) Nothing]
     , content' = note
     }
 
@@ -213,7 +213,7 @@ createEventDeletion eids reason xo t =
     , content' = reason
     }
   where
-    toDelete = map (\eid -> ETag eid Nothing Nothing) eids
+    toDelete = map (\eid -> ETag eid Nothing Nothing Nothing) eids
 
 
 createRelayListMetadataEvent :: [Relay] -> PubKeyXO -> Int -> UnsignedEvent
@@ -311,7 +311,7 @@ createGiftWrap sealEvent recipientPubKey = do
                 { pubKey' = keyPairToPubKeyXO randomKeyPair
                 , createdAt' = floor $ utcTimeToPOSIXSeconds currentTime
                 , kind' = GiftWrap
-                , tags' = [PTag recipientPubKey Nothing Nothing]
+                , tags' = [PListTag [recipientPubKey]]
                 , content' = wrapContent
                 }
           signEvent wrapEvent randomKeyPair >>= \case
@@ -385,18 +385,18 @@ getRootEventId = getRelationshipEventId Root
 
 
 -- | Get the relationship event ID.
-getRelationshipEventId :: Relationship -> Event -> Maybe EventId
+getRelationshipEventId :: Marker -> Event -> Maybe EventId
 getRelationshipEventId m e =
   if null replyList
     then Nothing
     else Just $ extractEventId $ head replyList
   where
-    replyFilter :: Relationship -> Tag -> Bool
-    replyFilter m' (ETag _ _ (Just m'')) = m' == m''
+    replyFilter :: Marker -> Tag -> Bool
+    replyFilter m' (ETag _ _ (Just m'') _) = m' == m''
     replyFilter _ _ = False
 
     replyList = filter (replyFilter m) $ tags e
 
     extractEventId :: Tag -> EventId
-    extractEventId (ETag eid _ _) = eid
+    extractEventId (ETag eid _ _ _) = eid
     extractEventId _ = error "Could not extract event id from reply or root tag"

--- a/src/Nostr/RelayConnection.hs
+++ b/src/Nostr/RelayConnection.hs
@@ -196,7 +196,6 @@ nostrClient connectionMVar r requestChan runE conn = runE $ do
         let pendingSubs = pendingSubscriptions st
         forM_ (Map.toList pendingSubs) $ \(subId', details) -> do
             atomically $ writeTChan requestChan (NT.Subscribe $ NT.Subscription subId' (subscriptionFilter details))
-            logDebug $ "Creating subscription from pending for " <> r <> " with subId " <> subId'
 
         -- Move pending subscriptions to active subscriptions
         modify @RelayPool $ \st' ->
@@ -226,6 +225,7 @@ nostrClient connectionMVar r requestChan runE conn = runE $ do
                     receiveLoop conn' q
                 Left err -> do
                     logError $ "Could not decode server response from " <> r <> ": " <> T.pack err
+                    logError $ "Msg: " <> T.pack (show msg')
                     receiveLoop conn' q
 
     sendLoop conn' = do
@@ -384,7 +384,7 @@ handleResponse relayURI' r = case r of
             st <- get @RelayPool
             case Map.lookup subId' (subscriptions st) of
                 Just sd -> atomically $ writeTQueue (responseQueue sd) (relayURI', event')
-                Nothing -> error $ "2 No subscription found for " <> show subId' <> " with response: " <> show r
+                Nothing -> error $ "2 No subscription found for " <> show subId' -- <> " with response: " <> show r
 
 
 -- | Handle authentication required.

--- a/src/Nostr/Types.hs
+++ b/src/Nostr/Types.hs
@@ -32,7 +32,7 @@ import Network.URI (URI(..), parseURI, uriAuthority, uriRegName, uriScheme)
 import Prelude hiding (until)
 import Text.Read (readMaybe)
 
-import Nostr.Keys (PubKeyXO(..), Signature, byteStringToHex, exportPubKeyXO, exportSignature)
+import Nostr.Keys (PubKeyXO(..), Signature, byteStringToHex, exportPubKeyXO, exportSignature, importPubKeyXO)
 
 -- | Represents a relay URI.
 type RelayURI = Text
@@ -216,8 +216,8 @@ instance Ord Kind where
 newtype EventId = EventId { getEventId :: ByteString } deriving (Eq, Ord)
 
 
--- | Represents a relationship type.
-data Relationship = Reply | Root | Mention
+-- | Represents a marker type.
+data Marker = Reply | Root | Mention
   deriving (Eq, Generic, Show)
 
 
@@ -237,8 +237,9 @@ data ExternalId
 
 -- | Represents a tag in an event.
 data Tag
-  = ETag EventId (Maybe RelayURI) (Maybe Relationship)
+  = ETag EventId (Maybe RelayURI) (Maybe Marker) (Maybe PubKeyXO)
   | PTag PubKeyXO (Maybe RelayURI) (Maybe DisplayName)
+  | PListTag [PubKeyXO]
   | QTag EventId (Maybe RelayURI) (Maybe PubKeyXO)
   | KTag Text
   | RTag Relay
@@ -447,13 +448,13 @@ instance FromJSON Tag where
   parseJSON v@(Array arr) =
     case V.toList arr of
       ("e":rest) -> either (const $ parseGenericTag v) return $ parseEither (parseETag rest) v
-      ("p":rest) -> parsePTag rest v
-      ("q":rest) -> parseQTag rest v
-      ("i":rest) -> parseITag rest v
-      ("k":rest) -> parseKTag rest v
-      ("r":rest) -> parseRTag rest v
-      ("relay":rest) -> parseRelayTag rest v
-      ("challenge":rest) -> parseChallengeTag rest v
+      ("p":rest) -> either (const $ parseGenericTag v) return $ parseEither (parsePTag rest) v
+      ("q":rest) -> either (const $ parseGenericTag v) return $ parseEither (parseQTag rest) v
+      ("i":rest) -> either (const $ parseGenericTag v) return $ parseEither (parseITag rest) v
+      ("k":rest) -> either (const $ parseGenericTag v) return $ parseEither (parseKTag rest) v
+      ("r":rest) -> either (const $ parseGenericTag v) return $ parseEither (parseRTag rest) v
+      ("relay":rest) -> either (const $ parseGenericTag v) return $ parseEither (parseRelayTag rest) v
+      ("challenge":rest) -> either (const $ parseGenericTag v) return $ parseEither (parseChallengeTag rest) v
       _          -> parseGenericTag v
   parseJSON v = parseGenericTag v
 
@@ -462,24 +463,43 @@ instance FromJSON Tag where
 parseETag :: [Value] -> Value -> Parser Tag
 parseETag rest _ = do
   case rest of
+    [eventIdVal, relayVal, markerVal, pubkeyVal] -> do
+      eventId <- parseJSONSafe eventIdVal
+      relay <- parseMaybeRelayURI relayVal
+      marker <- parseMaybeMarker markerVal
+      pubkey <- parseMaybePubKey pubkeyVal
+      return $ ETag eventId relay marker pubkey
     [eventIdVal, relayVal, markerVal] -> do
       eventId <- parseJSONSafe eventIdVal
       relay <- parseMaybeRelayURI relayVal
-      marker <- parseMaybeRelationship markerVal
-      return $ ETag eventId relay marker
+      marker <- parseMaybeMarker markerVal
+      return $ ETag eventId relay marker Nothing
     [eventIdVal, relayVal] -> do
       eventId <- parseJSONSafe eventIdVal
       relay <- parseMaybeRelayURI relayVal
-      return $ ETag eventId relay Nothing
+      return $ ETag eventId relay Nothing Nothing
     [eventIdVal] -> do
       eventId <- parseJSONSafe eventIdVal
-      return $ ETag eventId Nothing Nothing
+      return $ ETag eventId Nothing Nothing Nothing
     _ -> fail "Invalid ETag format"
 
 
 -- | Parses a PTag from a JSON array.
 parsePTag :: [Value] -> Value -> Parser Tag
-parsePTag rest _ = case rest of
+parsePTag rest v = do
+    -- First try to parse as PListTag (multiple pubkeys)
+    case rest of
+        -- If all values are strings, try parsing as PListTag
+        values@(_:_) ->
+            (do
+                pubkeys <- mapM parseJSONSafe values
+                return $ PListTag pubkeys)
+            <|> parseSinglePTag rest v  -- Fallback to single PTag parsing
+        _ -> parseSinglePTag rest v
+
+-- | Parses a single PTag (with optional relay and name)
+parseSinglePTag :: [Value] -> Value -> Parser Tag
+parseSinglePTag rest _ = case rest of
     (pubkeyVal : maybeRelay : maybeName : _) -> do
       pubkey <- parseJSONSafe pubkeyVal
       relay <- parseMaybeRelayURI maybeRelay
@@ -492,7 +512,7 @@ parsePTag rest _ = case rest of
     (pubkeyVal : _) -> do
       pubkey <- parseJSONSafe pubkeyVal
       return $ PTag pubkey Nothing Nothing
-    _ -> fail "Invalid PTag format"
+    [] -> fail "Invalid PTag format: empty array"
 
 
 -- | Parses a JSON value safely and returns the parsed result.
@@ -509,10 +529,10 @@ parseMaybeRelayURI Null = pure Nothing
 parseMaybeRelayURI _ = fail "Expected string or null for RelayURI"
 
 
--- | Parses a maybe relationship from a JSON value.
-parseMaybeRelationship :: Value -> Parser (Maybe Relationship)
-parseMaybeRelationship Null = return Nothing
-parseMaybeRelationship v = (Just <$> parseJSONSafe v) <|> return Nothing
+-- | Parses a maybe marker from a JSON value.
+parseMaybeMarker :: Value -> Parser (Maybe Marker)
+parseMaybeMarker Null = return Nothing
+parseMaybeMarker v = (Just <$> parseJSONSafe v) <|> return Nothing
 
 
 -- | Parses a maybe display name from a JSON value.
@@ -570,7 +590,7 @@ parseGenericTag v = fail $ "Expected array for generic tag, got: " ++ show v
 -- | Converts a 'Tag' to its JSON representation.
 instance ToJSON Tag where
   toEncoding tag = case tag of
-    ETag eventId relayURL marker ->
+    ETag eventId relayURL marker pubkey ->
       list id $
         [ text "e"
         , text $ decodeUtf8 $ B16.encode $ getEventId eventId
@@ -580,7 +600,8 @@ instance ToJSON Tag where
            Just Reply -> [text "reply"]
            Just Root -> [text "root"]
            Just Mention -> [text "mention"]
-           Nothing -> [])
+           Nothing -> []) ++
+        (maybe [] (\pk -> [text $ decodeUtf8 $ B16.encode $ exportPubKeyXO pk]) pubkey)
     PTag xo relayURL name ->
       list id $
         [ text "p"
@@ -588,6 +609,8 @@ instance ToJSON Tag where
         ] ++
         (maybe [] (\r -> [text r]) relayURL) ++
         (maybe [] (\n -> [text n]) name)
+    PListTag pubkeys ->
+      list id $ text "p" : map toEncoding pubkeys
     QTag eventId relayURL pubkey ->
       list id $
         [ text "q"
@@ -613,9 +636,9 @@ instance ToJSON Tag where
     GenericTag values -> list toEncoding values
 
 
--- | Converts a JSON string into a 'Relationship'.
-instance FromJSON Relationship where
- parseJSON = withText "Relationship" $ \m -> do
+-- | Converts a JSON string into a 'Marker'.
+instance FromJSON Marker where
+ parseJSON = withText "Marker" $ \m -> do
    case T.toLower m of
      "reply" -> return Reply
      "root"  -> return Root
@@ -623,8 +646,8 @@ instance FromJSON Relationship where
      _       -> mzero
 
 
--- | Converts a 'Relationship' to its JSON representation.
-instance ToJSON Relationship where
+-- | Converts a 'Marker' to its JSON representation.
+instance ToJSON Marker where
   toEncoding Reply = text "reply"
   toEncoding Root = text "root"
   toEncoding Mention = text "mention"
@@ -896,3 +919,11 @@ instance FromJSON ExternalId where
 instance ToJSON ExternalId where
   toEncoding = text . externalIdToText
   toJSON = String . externalIdToText
+
+-- | Parses a maybe pubkey from a JSON value.
+parseMaybePubKey :: Value -> Parser (Maybe PubKeyXO)
+parseMaybePubKey Null = return Nothing
+parseMaybePubKey (String s) = case decodeHex s of
+    Just bs | BS.length bs == 32 -> return $ importPubKeyXO bs
+    _ -> fail "Invalid pubkey format"
+parseMaybePubKey _ = fail "Expected string or null for pubkey"

--- a/src/UI.hs
+++ b/src/UI.hs
@@ -34,7 +34,7 @@ import Nostr.Event (createMetadata)
 import Nostr.Publisher
 import Nostr.Keys (PubKeyXO, keyPairToPubKeyXO)
 import Nostr.Types ( Event(..), EventId(..), Kind(..), Profile(..), RelayURI
-                   , Relationship(..), Rumor(..), Tag(..) )
+                   , Marker(..), Rumor(..), Tag(..) )
 import Nostr.Util
 import Presentation.KeyMgmtUI qualified as KeyMgmtUI
 import Presentation.RelayMgmtUI qualified as RelayMgmtUI
@@ -164,13 +164,13 @@ runUI = interpret $ \_ -> \case
     followPool <- newFactoryPool (newObject followClass)
 
     let getRootReference evt =
-          case find (\case ETag _ _ (Just Root) -> True; _ -> False) (tags evt) of
-            Just (ETag eid _ _) -> return $ Just eid
+          case find (\case ETag _ _ (Just Root) _ -> True; _ -> False) (tags evt) of
+            Just (ETag eid _ _ _) -> return $ Just eid
             _ -> return Nothing
 
         getParentReference evt =
-          case find (\case ETag _ _ (Just Reply) -> True; _ -> False) (tags evt) of
-            Just (ETag eid _ _) -> return $ Just eid
+          case find (\case ETag _ _ (Just Reply) _ -> True; _ -> False) (tags evt) of
+            Just (ETag eid _ _ _) -> return $ Just eid
             _ -> return Nothing
 {-
         getEventCount subscriber postId = do
@@ -279,7 +279,7 @@ runUI = interpret $ \_ -> \case
           case eventMaybe of
             Just eventWithRelays -> do
               let ev = event eventWithRelays
-                  eTagRefs = [tagId | ETag tagId _ _ <- tags ev]
+                  eTagRefs = [tagId | ETag tagId _ _ _ <- tags ev]
                   qTagRefs = [tagId | QTag tagId _ _ <- tags ev]
                   contentRefs = extractNostrReferences (content ev)
                   allRefs = nub $ eTagRefs ++ qTagRefs ++ contentRefs
@@ -357,7 +357,6 @@ runUI = interpret $ \_ -> \case
           case signedMaybe of
             Just signed -> do
               runE $ broadcast signed
-              runE $ logInfo "Profile successfully saved and sent to relay pool"
             Nothing -> runE $ logWarning "Failed to sign profile update event",
 
         defPropertySigRO' "followList" changeKey' $ \obj -> do


### PR DESCRIPTION
- Add PTagList variant for handling multiple pubkeys
- Rename Relationship to Marker for clarity
- Add pubkey field to ETag for better NIP compliance
- Improve tag parsing with better error handling
- Fix collectEventsUntilEose to wait for all relay EOSE signals
- Remove redundant relay field from follow list comparison
- Optimize profile and event caching with invalidation on updates
- Fix event deletion by properly clearing caches and databases
- Make post and private message views consistent in styling and behavior
- Improve timeline cache handling and event updates
- Remove redundant event caching in publisher