### PR TITLE
improve UI update handling with granular object signaling

### DIFF
--- a/src/Futr.hs
+++ b/src/Futr.hs
@@ -234,7 +234,7 @@ runFutr = interpret $ \_ -> \case
       _ -> return ()
 
     modify @AppState $ \st' -> st' { currentProfile = Just (pk, []) }
-    notify $ emptyUpdates { profilesChanged = True, postsChanged = True, privateMessagesChanged = True }
+    notify $ emptyUpdates { postsChanged = True, privateMessagesChanged = True }
 
     void $ async $ do
       kp <- getKeyPair


### PR DESCRIPTION
Replaces global profile/post updates with targeted object signaling to improve performance and reduce unnecessary UI refreshes. Removes profilesChanged flag and adds object-specific signal lists for posts, profiles and general objects.