### PR TITLE
UI signals profile changes

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,6 +14,7 @@ import Logging (runLoggingStdout)
 import Nostr
 import Nostr.EventHandler (runEventHandler)
 import Nostr.InboxModel (runInboxModel)
+import Nostr.ProfileManager (ProfileManagerState, initialProfileManagerState, runProfileManager)
 import Nostr.Publisher (runPublisher)
 import Nostr.RelayConnection (runRelayConnection)
 import Nostr.Subscription (runSubscription)
@@ -55,6 +56,7 @@ main = do
         . runSubscription
         . runSubscriptionHandler
         . runInboxModel
+        . runProfileManager
         -- presentation related
         . runKeyMgmtUI
         . runRelayMgmtUI
@@ -89,10 +91,12 @@ withInitialState
            : State KeyMgmtState
            : State AppState
            : State LmdbState
+           : State ProfileManagerState
            : es) a
     -> Eff es a
 withInitialState
-    = evalState initialLmdbState
+    = evalState initialProfileManagerState
+    . evalState initialLmdbState
     . evalState initialState
     . evalState initialKeyMgmtState
     . evalState initialRelayPool

--- a/futr.cabal
+++ b/futr.cabal
@@ -42,6 +42,7 @@ executable futr
         Nostr.InboxModel
         Nostr.Keys
         Nostr.Profile
+        Nostr.ProfileManager
         Nostr.Publisher
         Nostr.Relay
         Nostr.RelayConnection

--- a/src/Nostr/Profile.hs
+++ b/src/Nostr/Profile.hs
@@ -43,7 +43,6 @@ data Nip05Response = Nip05Response
   } deriving (Show)
 
 
-
 -- | 'ToJSON' instance for 'Profile'.
 instance ToJSON Profile where
   toEncoding (Profile n dn abt pic nip bnr) = pairs $

--- a/src/Nostr/ProfileManager.hs
+++ b/src/Nostr/ProfileManager.hs
@@ -1,0 +1,98 @@
+module Nostr.ProfileManager where
+
+import Control.Monad (forM_, void, when)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
+import Data.Set qualified as Set
+import Effectful
+import Effectful.Concurrent
+import Effectful.Concurrent.Async (async)
+import Effectful.Dispatch.Dynamic (interpret)
+import Effectful.State.Static.Shared (State, get, modify)
+import Effectful.TH
+
+import Nostr.Event (Kind(..))
+import Nostr.Keys (PubKeyXO)
+import Nostr.Profile (Profile)
+import Nostr.Relay (RelayURI)
+import Nostr.Subscription (Subscription, metadataFilter, subscribe)
+import Nostr.SubscriptionHandler (SubscriptionHandler, handleSubscriptionUntilEOSE)
+import Nostr.Types (Filter(..))
+import Nostr.Util
+import Store.Lmdb (LmdbStore)
+import Store.Lmdb qualified as Lmdb
+import Types
+
+data ProfileManagerState = ProfileManagerState
+    { lastFetchAttempts :: Map.Map PubKeyXO Int  -- pubkey -> timestamp of last fetch attempt
+    , pendingFetches :: Set.Set PubKeyXO
+    }
+
+initialProfileManagerState :: ProfileManagerState
+initialProfileManagerState = ProfileManagerState
+    { lastFetchAttempts = Map.empty
+    , pendingFetches = Set.empty
+    }
+
+data ProfileManager :: Effect where
+    GetProfile :: PubKeyXO -> ProfileManager m (Profile, Int)
+    FetchProfile :: PubKeyXO -> [RelayURI] -> ProfileManager m (Profile, Int)
+
+type instance DispatchOf ProfileManager = Dynamic
+
+makeEffect ''ProfileManager
+
+type ProfileManagerEff es =
+    ( LmdbStore :> es
+    , Subscription :> es
+    , SubscriptionHandler :> es
+    , Util :> es
+    , State ProfileManagerState :> es
+    , State RelayPool :> es
+    , Concurrent :> es
+    )
+
+runProfileManager :: ProfileManagerEff es => Eff (ProfileManager : es) a -> Eff es a
+runProfileManager = interpret $ \_ -> \case
+    GetProfile pk -> fetchProfileImpl pk []
+    FetchProfile pk relayHints -> fetchProfileImpl pk relayHints
+
+-- Helper function containing the common implementation
+fetchProfileImpl :: ProfileManagerEff es => PubKeyXO -> [RelayURI] -> Eff es (Profile, Int)
+fetchProfileImpl pk relayHints = do
+    (profile, profileTimestamp) <- Lmdb.getProfile pk
+
+    void $ async $ do
+        currentTime <- getCurrentTime
+        st <- get @ProfileManagerState
+
+        relayPoolSt <- get @RelayPool
+        let isActiveFetch = any (\sub ->
+              let filter' = subscriptionFilter sub
+              in pk `elem` fromMaybe [] (authors filter')
+                 && maybe False (Metadata `elem`) (kinds filter'))
+              (Map.elems $ subscriptions relayPoolSt)
+            isPendingFetch = pk `Set.member` pendingFetches st
+
+        let lastFetchAttempt = fromMaybe 0 $ Map.lookup pk (lastFetchAttempts st)
+            timeSinceLastFetch = currentTime - lastFetchAttempt
+            shouldFetch = not (isActiveFetch || isPendingFetch) &&
+                         (profileTimestamp == 0 || timeSinceLastFetch > 24 * 60 * 60)
+
+        when shouldFetch $ do
+            modify @ProfileManagerState $ \s -> s
+                { lastFetchAttempts = Map.insert pk currentTime (lastFetchAttempts s)
+                , pendingFetches = Set.insert pk (pendingFetches s)
+                }
+
+            let connectedRelays = Map.keys $ Map.filter (\rd -> connectionState rd == Connected) $ activeConnections relayPoolSt
+            let targetRelays = if null relayHints then connectedRelays else relayHints
+
+            forM_ targetRelays $ \relayUri -> do
+                subId' <- subscribe relayUri (metadataFilter [pk])
+                void $ handleSubscriptionUntilEOSE subId'
+
+            modify @ProfileManagerState $ \s -> s
+                { pendingFetches = Set.delete pk (pendingFetches s) }
+
+    return (profile, profileTimestamp)

--- a/src/Nostr/Subscription.hs
+++ b/src/Nostr/Subscription.hs
@@ -142,6 +142,15 @@ profilesFilter pks = emptyFilter
     }
 
 
+-- | Creates a filter for fetching metadata.
+metadataFilter :: [PubKeyXO] -> Filter
+metadataFilter pks = emptyFilter
+    { authors = Just pks
+    , kinds = Just [Metadata]
+    , limit = Just $ 50 * length pks
+    }
+
+
 -- | Creates a filter for fetching a user's public posts and interactions.
 --
 -- This filter targets three event kinds:
@@ -158,10 +167,6 @@ userPostsFilter pks s ml = emptyFilter
         Nothing -> Just $ 500 * length pks
     }
 
-
--- | Creates a filter for metadata.
-metadataFilter :: [PubKeyXO] -> Filter
-metadataFilter pks = emptyFilter { authors = Just pks, kinds = Just [Metadata] }
 
 -- | Creates a filter for short text notes.
 shortTextNoteFilter :: [PubKeyXO] -> Filter


### PR DESCRIPTION
- Add ProfileManager effect to manage profile fetching and caching
- Track fetch attempts in memory to prevent duplicate fetches
- Return profile timestamps with GetProfile calls
- Use relay hints from nprofile for targeted fetching
- Update all profile consumers to handle timestamp information
- Adds proper signaling of content updates when referenced profiles change
- Store profile content references when parsing post content
- Signal content updates when profile metadata changes